### PR TITLE
Add scripts to get CPU core count in Python and Bash

### DIFF
--- a/get_cpu_cores.py
+++ b/get_cpu_cores.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import os
+import multiprocessing
+
+def get_cpu_core_count():
+    """
+    获取机器的CPU核数
+    Returns the number of CPU cores on the machine
+    """
+    try:
+        # 方法1: 使用multiprocessing.cpu_count()
+        cpu_count = multiprocessing.cpu_count()
+        print(f"CPU核数 (CPU Core Count): {cpu_count}")
+        
+        # 方法2: 使用os.cpu_count() (Python 3.4+)
+        os_cpu_count = os.cpu_count()
+        if os_cpu_count:
+            print(f"CPU核数 (via os.cpu_count): {os_cpu_count}")
+        
+        return cpu_count
+        
+    except Exception as e:
+        print(f"获取CPU核数时出错: {e}")
+        return None
+
+if __name__ == "__main__":
+    core_count = get_cpu_core_count()
+    if core_count:
+        print(f"\n当前机器有 {core_count} 个CPU核")
+    else:
+        print("无法获取CPU核数")

--- a/get_cpu_cores.sh
+++ b/get_cpu_cores.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# 获取CPU核数的脚本
+# Script to get CPU core count
+
+echo "=== CPU核数信息 / CPU Core Count Information ==="
+
+# 方法1: 使用nproc命令
+if command -v nproc >/dev/null 2>&1; then
+    cores=$(nproc)
+    echo "CPU核数 (nproc): $cores"
+fi
+
+# 方法2: 从/proc/cpuinfo读取
+if [ -f /proc/cpuinfo ]; then
+    cores_proc=$(grep -c ^processor /proc/cpuinfo)
+    echo "CPU核数 (from /proc/cpuinfo): $cores_proc"
+fi
+
+# 方法3: 使用lscpu命令
+if command -v lscpu >/dev/null 2>&1; then
+    cores_lscpu=$(lscpu | grep "^CPU(s):" | awk '{print $2}')
+    echo "CPU核数 (lscpu): $cores_lscpu"
+fi
+
+# 输出最终结果
+if command -v nproc >/dev/null 2>&1; then
+    final_count=$(nproc)
+    echo ""
+    echo "当前机器有 $final_count 个CPU核"
+else
+    echo ""
+    echo "无法确定准确的CPU核数"
+fi


### PR DESCRIPTION
## Summary
- Introduces a Python script to retrieve the number of CPU cores using `multiprocessing` and `os` modules
- Adds a Bash script to fetch CPU core count using multiple methods (`nproc`, `/proc/cpuinfo`, `lscpu`)

## Changes

### Python Script (`get_cpu_cores.py`)
- Implements `get_cpu_core_count` function to get CPU core count
- Prints CPU core count using two methods: `multiprocessing.cpu_count()` and `os.cpu_count()`
- Handles exceptions gracefully and provides user-friendly output

### Bash Script (`get_cpu_cores.sh`)
- Prints CPU core count information using:
  - `nproc` command
  - Counting processors in `/proc/cpuinfo`
  - `lscpu` command
- Provides a final summary of CPU core count or an error message if unavailable

## Test plan
- Run `get_cpu_cores.py` to verify it prints CPU core count correctly
- Execute `get_cpu_cores.sh` on Linux systems to confirm accurate CPU core count retrieval
- Validate error handling by simulating missing commands or files

This addition helps in easily determining CPU core count across different environments using both Python and shell scripts.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/82163ef8-074f-49aa-909e-1fa4b264d303